### PR TITLE
feat: add Laravel QRIS tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# Composer vendor directory
+/vendor/
+
+# Dependency lock file (optional for libraries)
+composer.lock
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# IDE / Editor configs
+/.idea/
+/.vscode/
+/nbproject/
+/*.sublime-*
+/*.swp
+
+# PHPUnit / Testing
+.phpunit.result.cache
+.phpunit.cache
+coverage/
+tests/_output/
+
+# Logs
+*.log
+
+# Cache
+.cache/
+.php_cs.cache

--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ Library PHP yang powerful untuk **generate**, **parse**, dan **convert** QRIS (Q
 composer require kodinus/dynamicgen-qris
 ```
 
+### Penggunaan di Laravel
+
+Paket ini mendukung *auto-discovery* sehingga Anda bisa langsung memakai **Facade** `Qris`
+atau *dependency injection* `DynamicQRISGenerator` di dalam project Laravel Anda.
+
+```php
+use Qris; // Facade
+
+$qris = Qris::generate($merchantData, 50000);
+$data = Qris::extractMerchant($qris);
+```
+
 ## 🔧 Setup Awal
 
 ```php

--- a/composer.json
+++ b/composer.json
@@ -8,9 +8,18 @@
             "Kodinus\\DynamicGenQris\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Kodinus\\DynamicGenQris\\Tests\\": "tests/"
+        }
+    },
     "require": {
         "php": ">=8.0",
         "illuminate/support": "^10.0|^11.0"
+    },
+    "require-dev": {
+        "orchestra/testbench": "^9.0",
+        "phpunit/phpunit": "^10.0"
     },
     "authors": [
         {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+    <testsuites>
+        <testsuite name="DynamicGenQris Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/QrisServiceProvider.php
+++ b/src/QrisServiceProvider.php
@@ -16,6 +16,8 @@ class QrisServiceProvider extends ServiceProvider
         $this->app->singleton('qris.generator', function () {
             return new DynamicQRISGenerator();
         });
+
+        $this->app->alias('qris.generator', DynamicQRISGenerator::class);
     }
 
     /**

--- a/tests/QrisGeneratorTest.php
+++ b/tests/QrisGeneratorTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Kodinus\DynamicGenQris\Tests;
+
+use Kodinus\DynamicGenQris\DynamicQRISGenerator;
+use Kodinus\DynamicGenQris\Facades\Qris;
+
+class QrisGeneratorTest extends TestCase
+{
+    public function test_service_provider_binds_generator(): void
+    {
+        $this->assertInstanceOf(
+            DynamicQRISGenerator::class,
+            $this->app->make('qris.generator')
+        );
+    }
+
+    public function test_it_generates_and_parses_qris(): void
+    {
+        $merchantData = [
+            'acquirer_domain'   => 'COM.GO-JEK.WWW',
+            'mpan'              => '936009143805979959',
+            'terminal_id'       => 'G805979959',
+            'merchant_category' => 'UMI',
+            'nmid'              => 'ID1024358806544',
+            'mcc'               => '5411',
+            'merchant_name'     => 'Kodingin Digital Nusantara',
+            'merchant_city'     => 'NGAWI',
+            'postal_code'       => '63281',
+        ];
+
+        $qris = Qris::generate($merchantData, 50000);
+
+        $this->assertNotEmpty($qris);
+
+        $parsed = Qris::extractMerchant($qris);
+
+        $this->assertSame('Kodingin Digital Nusantara', $parsed['merchant_name']);
+        $this->assertSame('NGAWI', $parsed['merchant_city']);
+        $this->assertSame(50000.0, $parsed['amount']);
+        $this->assertTrue($parsed['is_dynamic']);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Kodinus\DynamicGenQris\Tests;
+
+use Orchestra\Testbench\TestCase as Orchestra;
+use Kodinus\DynamicGenQris\QrisServiceProvider;
+use Kodinus\DynamicGenQris\Facades\Qris;
+
+class TestCase extends Orchestra
+{
+    protected function getPackageProviders($app)
+    {
+        return [QrisServiceProvider::class];
+    }
+
+    protected function getPackageAliases($app)
+    {
+        return ['Qris' => Qris::class];
+    }
+}


### PR DESCRIPTION
## Summary
- expose DynamicQRISGenerator binding for class-based injection
- document Laravel facade usage
- add PHPUnit + Testbench setup with basic facade tests

## Testing
- `composer update --quiet` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8fd7f5988328a5d29249d342f116