### PR TITLE
Expand illuminate/support compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ composer require kodinus/dynamicgen-qris
 ### Penggunaan di Laravel
 
 Paket ini mendukung *auto-discovery* sehingga Anda bisa langsung memakai **Facade** `Qris`
-atau *dependency injection* `DynamicQRISGenerator` di dalam project Laravel Anda.
+atau *dependency injection* `DynamicQRISGenerator` di dalam project Laravel Anda. Paket ini
+kompatibel dengan Laravel 8.x hingga 11.x.
 
 ```php
 use Qris; // Facade

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require": {
         "php": ">=8.0",
-        "illuminate/support": "^10.0|^11.0"
+        "illuminate/support": "^8.0|^9.0|^10.0|^11.0"
     },
     "require-dev": {
         "orchestra/testbench": "^9.0",


### PR DESCRIPTION
## Summary
- support illuminate/support down to v8
- document Laravel 8-11 compatibility

## Testing
- `composer update --no-interaction` *(fails: curl error 56 while downloading packages.json)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bf956d7fb48328910ff548c7a5e375