### PR TITLE
feat: add terminal QR code printing

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,26 @@ if ($isValid) {
 }
 ```
 
+### 7. Cetak QR Code di Terminal
+
+Untuk menampilkan QR Code langsung di terminal, instal terlebih dahulu dependensi tambahan:
+
+```bash
+composer require bacon/bacon-qr-code
+```
+
+Kemudian panggil metode `printQrCode` baik melalui instance kelas maupun Facade:
+
+```php
+// Menggunakan instance kelas
+$generator->printQrCode($dynamicQris);
+
+// Atau melalui Facade di Laravel
+Qris::printQrCode($dynamicQris);
+```
+
+Metode ini akan mencetak QR Code dalam bentuk teks ASCII ke terminal.
+
 ## 📋 Parameter Merchant Data
 
 Pastikan parameter _Merchant Data_ sesuai dengan hasil pembacaan QR Code yang ada dari QRIS milik anda.

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     },
     "require": {
         "php": ">=8.0",
-        "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0"
+        "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0",
+        "bacon/bacon-qr-code": "^2.0"
     },
     "require-dev": {
         "orchestra/testbench": "^9.0",

--- a/src/DynamicQRISGenerator.php
+++ b/src/DynamicQRISGenerator.php
@@ -4,6 +4,7 @@ namespace Kodinus\DynamicGenQris;
 
 use Exception;
 use InvalidArgumentException;
+use RuntimeException;
 
 /**
  * QRIS Generator & Parser
@@ -482,6 +483,29 @@ class DynamicQRISGenerator
         } catch (Exception $e) {
             return false;
         }
+    }
+
+    /**
+     * Cetak QR Code dalam bentuk teks ke terminal menggunakan bacon/bacon-qr-code.
+     *
+     * @param string $string String yang akan di-encode menjadi QR Code.
+     * @return string Representasi teks dari QR Code.
+     *
+     * @throws RuntimeException Jika dependensi bacon/bacon-qr-code tidak terpasang.
+     */
+    public function printQrCode(string $string): string
+    {
+        if (!class_exists(\BaconQrCode\Writer::class)) {
+            throw new RuntimeException('bacon/bacon-qr-code package is required. Install via composer require bacon/bacon-qr-code.');
+        }
+
+        $renderer = new \BaconQrCode\Renderer\PlainTextRenderer();
+        $writer = new \BaconQrCode\Writer($renderer);
+        $qrCode = $writer->writeString($string);
+
+        echo $qrCode . PHP_EOL;
+
+        return $qrCode;
     }
 
     /**

--- a/tests/QrisGeneratorTest.php
+++ b/tests/QrisGeneratorTest.php
@@ -40,4 +40,29 @@ class QrisGeneratorTest extends TestCase
         $this->assertSame(50000.0, $parsed['amount']);
         $this->assertTrue($parsed['is_dynamic']);
     }
+
+    public function test_print_qr_code_via_generator(): void
+    {
+        $generator = new DynamicQRISGenerator();
+        if (class_exists(\BaconQrCode\Writer::class)) {
+            $this->expectOutputRegex('/.+/');
+            $result = $generator->printQrCode('Hello');
+            $this->assertIsString($result);
+            $this->assertNotEmpty($result);
+        } else {
+            $this->expectException(\RuntimeException::class);
+            $generator->printQrCode('Hello');
+        }
+    }
+
+    public function test_print_qr_code_via_facade(): void
+    {
+        if (class_exists(\BaconQrCode\Writer::class)) {
+            $this->expectOutputRegex('/.+/');
+            Qris::printQrCode('Hello');
+        } else {
+            $this->expectException(\RuntimeException::class);
+            Qris::printQrCode('Hello');
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add bacon/bacon-qr-code dependency
- allow generator or facade to print QR codes in the terminal
- document new printQrCode usage and cover with tests

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa2e919b4832891ba2d2e71ae41d4